### PR TITLE
Cleaner file names, logs, progress bar, options...

### DIFF
--- a/bandcampdl/downloader.py
+++ b/bandcampdl/downloader.py
@@ -7,53 +7,84 @@ from click import echo
 from parsel import Selector
 import os
 import re
+from datetime import datetime
 
+do_dry_run = False
+do_force = False
 
 def clean(text):
-    text = text.replace(os.sep, '')
-    text = text.lower().strip().replace(' ', '_')
-    text = re.sub('_{2,}', '_', text)
-    text = text.replace('_-_', '-')
+    text = text.strip()
+    text = text.replace(os.sep, '-')
     return text
+
+def download(url, path):
+    global do_dry_run
+    if do_dry_run:
+        return
+    r = requests.get(url, stream=True)
+    length = int(r.headers['Content-Length'])
+    with open(path, 'wb') as f, \
+         click.progressbar(length=length) as bar:
+        for chunk in r.iter_content(chunk_size=4096):
+            if chunk: # filter out keep-alive new chunks
+                f.write(chunk)
+                bar.update(len(chunk))
 
 
 @click.command()
 @click.argument('url')
-def cli(url):
+@click.option('--force/--no-force', default=False)
+@click.option('--dry-run/--no-dry-run', default=False)
+@click.help_option('-h', '--help')
+def cli(url, force, dry_run):
     """
     Download tracks from bandcamp album url to `<cwd>/<album_name>/` directory
     """
+    global do_dry_run
+    do_dry_run = dry_run
+    global do_force
+    do_force = force
+
     resp = requests.get(url)
     sel = Selector(text=resp.text)
     album_name = clean(sel.xpath('//h2[@itemprop="name"]/text()').extract_first(''))
     artist = clean(sel.xpath('//span[@itemprop="byArtist"]/a/text()').extract_first(''))
+    album_date = datetime.strptime(next(re.finditer('album_release_date: "(.+)"', resp.text)).group(1), '%d %b %Y %H:%M:%S %Z')
+    tags = map(clean, sel.xpath('//div[has-class("tralbumData", "tralbum-tags")]/a[has-class("tag") and @itemprop="keywords"]/text()').extract())
     if not album_name:
-        echo('no album found on: {}'.format(resp.url), err=True)
+        echo('No album found on: {}'.format(resp.url), err=True)
         return 1
-    album_path = os.path.join(os.getcwd(), album_name)
-    echo('downloading album: {}\nto: {}'.format(album_name, album_path))
+    album_path = os.path.join(os.getcwd(), artist, '{} - {}'.format(album_date.year, album_name))
+    echo("""\
+Downloading album {album} ({year}) by {artist}
+  to: {path}
+(tags: {tags})
+""".format(artist=artist, year=album_date.year, album=album_name, path=album_path, tags=', '.join(tags)))
     try:
-        os.mkdir(album_path)
+        if not do_dry_run:
+            os.makedirs(album_path)
     except FileExistsError:
-        print('Error: Directory "{}" already exists'.format(album_path))
-        sys.exit()
-    tracks = json.loads(re.findall('trackinfo: (\[.+\])', resp.text)[0])
-    for track in tracks:
+        if do_force:
+            echo('Warning: Directory "{}" already exists. Used --force: continuing.'.format(album_path))
+        else:
+            echo('Error: Directory "{}" already exists. Use --force to continue.'.format(album_path), err=True)
+            sys.exit(1)
+    tracks = json.loads(next(re.finditer('trackinfo: (\[.+\])', resp.text)).group(1))
+    for i, track in enumerate(tracks):
         if not track['file']:
             echo('warning: skipping track "{}" - not available to download'.format(track['title']))
             continue
         url = track['file']['mp3-128']
         if not url.startswith('http'):
             url = 'http:' + url
-        name = '{}-{}.mp3'.format(artist, clean(track['title']))
-        echo('downloading track: {}'.format(name))
-        with open(os.path.join(album_path, name), 'wb') as f:
-            f.write(requests.get(url).content)
+        name = '{:02} - {}.mp3'.format(track["track_num"], clean(track['title']))
+        echo('downloading track {}/{}: {}'.format(i+1, len(tracks), name))
+        download(url, os.path.join(album_path, name))
+
     cover = sel.css('#tralbumArt img::attr(src)').extract_first()
     if cover:
         echo('downloading cover.jpg')
-        with open(os.path.join(album_path, 'cover.jpg'), 'wb') as f:
-            f.write(requests.get(cover).content)
+        download(cover, os.path.join(album_path, 'cover.jpg'))
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
- stop mangling with names: keep them as close to the original as
possible (just replace `/` by `-` for filesystem support)
- file path is now `{artist}/{album_year} - {album_name}/{track_number} - {track_name}.mp3`
- display more information: artist, album year, name and tags
- add a nice progress bar for the download of each track
- `--force`: option to force download when target directory exists
- `--dry-run`: option to *not* write anything to disk, but still get and
parse the url (useful for debug)
- exit with code 1 on error

Internals:
- replaced `re.findall()[0]` by `re.finditer()`: more efficient